### PR TITLE
Add Validation Rules for Additional Fields to Resolve Crash Issue

### DIFF
--- a/app/Http/Requests/ContactInfoUpdateRequest.php
+++ b/app/Http/Requests/ContactInfoUpdateRequest.php
@@ -22,7 +22,7 @@ class ContactInfoUpdateRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'phone' => ['nullable', 'string'],
+            'phone' => ['nullable', 'string', 'max:15'],
             'website' => ['nullable', 'url'],
         ];
     }

--- a/app/Http/Requests/PersonalInfoUpdateRequest.php
+++ b/app/Http/Requests/PersonalInfoUpdateRequest.php
@@ -26,14 +26,14 @@ class PersonalInfoUpdateRequest extends FormRequest
 
         return [
             'name' => ['required', 'string', 'max:255'],
-            'address' => ['nullable', 'string'],
-            'dob' => ['nullable', 'date'],
-            'state' => ['nullable', 'string'],
-            'country' => ['nullable', 'string'],
-            'occupation' => ['nullable', 'string'],
+            'address' => ['nullable', 'string',],
+            'dob' => ['nullable', 'date', 'max:100'],
+            'state' => ['nullable', 'string', 'max:100'],
+            'country' => ['nullable', 'string', 'max:100'],
+            'occupation' => ['nullable', 'string', 'max:100'],
             'timezone'  => ['nullable', 'string', Rule::in(Timezone::toValues())],
-            'postcode' => ['nullable', 'string'],
-            'phone' => ['nullable', 'string'],
+            'postcode' => ['nullable', 'string', 'max:15'],
+            'phone' => ['nullable', 'string', 'max:20'],
             'bio' => ['nullable', 'string'],
         ];
     }

--- a/app/Http/Requests/SocialMediaInfoUpdateRequest.php
+++ b/app/Http/Requests/SocialMediaInfoUpdateRequest.php
@@ -22,10 +22,10 @@ class SocialMediaInfoUpdateRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'facebook' => ['nullable', 'string'],
-            'twitter' => ['nullable', 'string'],
-            'linkedin' => ['nullable', 'string'],
-            'github' => ['nullable', 'string'],
+            'facebook' => ['nullable', 'string', 'max:255'],
+            'twitter' => ['nullable', 'string', 'max:255'],
+            'linkedin' => ['nullable', 'string', 'max:255'],
+            'github' => ['nullable', 'string', 'max:255'],
         ];
     }
 

--- a/app/Http/Requests/UpdateExperienceRequest.php
+++ b/app/Http/Requests/UpdateExperienceRequest.php
@@ -23,6 +23,7 @@ class UpdateExperienceRequest extends FormRequest
     {
         return [
             'position' => ['required', 'array'],
+            'position.*' => ['required', 'string', 'max:20'],
             'company_name' => ['required', 'array'],
             'currently_working' => [],
             'start_date' => ['required', 'array'],


### PR DESCRIPTION
This pull request introduces new validation rules for the following fields:

- Phone Number
- Occupation
- State
- Country
- GitHub
- Facebook
- Twitter

These changes address a crash issue caused by invalid or missing input data. By adding these validation rules, the application ensures proper input handling and improves overall stability.

