### PR TITLE
display a user-friendly message when no job category exists during job creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,21 +56,45 @@ php artisan key:generate
 OPENAI_API_KEY=your_openai_api_key
 ```
 
-5. Set up Laravel Reverb for WebSocket:
+5. Run migrations
+```bash
+php artisan migrate
+```
+
+6. Set up Laravel Reverb for WebSocket:
 ```bash
 php artisan reverb:install
 php artisan reverb:start
-```
-
-6. Run migrations
-```bash
-php artisan migrate
 ```
 
 7. Start the development server
 ```bash
 php artisan serve
 npm run dev
+```
+
+8. Add Job Category
+- Add a job category via the admin panel: `/geezap/job-categories`.
+- Admin credential are available in the seeder class
+
+9. Add API-Key
+- Add API Keys for job search via admin panel: `/geezap/api-keys`.
+
+10. Run the Scheduler
+```bash
+php artisan schedule:run
+```
+
+1.   Run the queue worker
+```bash
+php artisan queue:work
+```
+
+**Notes**
+- If you don't get expected behavior check `laravel.log` file
+- Following command might be helpful in some cases
+```bash
+php artisan cache:clear
 ```
 
 ## 💻 Technologies Used
@@ -98,11 +122,11 @@ npm run dev
 - **Advanced Job Matching**
     - AI-powered job recommendations
     - Skill compatibility scoring
- 
+
 - **Social Media Sharing**
     - Share job listings on platforms like LinkedIn, Twitter, and Facebook.
-   
-      
+
+
 ## 🤝 Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.

--- a/app/Exceptions/CategoryNotFoundException.php
+++ b/app/Exceptions/CategoryNotFoundException.php
@@ -3,11 +3,19 @@
 namespace App\Exceptions;
 
 use Exception;
+use Illuminate\Database\Eloquent\Collection;
 
 class CategoryNotFoundException extends Exception
 {
     public function __construct()
     {
         parent::__construct('No job categories are available. Please add categories before creating a new job listing.');
+    }
+
+    public static function throwIfNotFound(Collection $categories)
+    {
+        if ($categories->count() === 0) {
+            throw new self();
+        }
     }
 }

--- a/app/Exceptions/CategoryNotFoundException.php
+++ b/app/Exceptions/CategoryNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class CategoryNotFoundException extends Exception
+{
+    public function __construct()
+    {
+        parent::__construct('No job categories are available. Please add categories before creating a new job listing.');
+    }
+}

--- a/app/Filament/Resources/JobCategoryResource.php
+++ b/app/Filament/Resources/JobCategoryResource.php
@@ -25,7 +25,7 @@ class JobCategoryResource extends Resource
         return $form
             ->schema([
                 Forms\Components\TextInput::make('name')
-                    ->hint('This is the number of the category')
+                    ->hint('This is the name of the category')
                     ->hintColor('info')
                     ->hintIcon('heroicon-o-exclamation-circle')
                     ->required()

--- a/app/Filament/Resources/JobListingResource.php
+++ b/app/Filament/Resources/JobListingResource.php
@@ -36,7 +36,8 @@ class JobListingResource extends Resource
                             ->options(JobType::class)
                             ->required(),
                         Forms\Components\Select::make('job_category')
-                            ->options(JobCategory::getAllCategories()->pluck('name', 'id')->toArray()),
+                            ->options(JobCategory::getAllCategories()->pluck('name', 'id')->toArray())
+                            ->required(),
                         Forms\Components\RichEditor::make('description')
                             ->required()
                             ->columnSpanFull(),
@@ -145,7 +146,7 @@ class JobListingResource extends Resource
                     Tables\Actions\Action::make('view')
                         ->label('View')
                         ->icon('heroicon-o-eye')
-                        ->url(function ($record){
+                        ->url(function ($record) {
                             return route('job.show', $record->slug);
                         })
                         ->openUrlInNewTab(),

--- a/app/Jobs/GetJobData.php
+++ b/app/Jobs/GetJobData.php
@@ -41,9 +41,7 @@ class GetJobData implements ShouldQueue
 
             $categories = JobCategory::all();
 
-            if ($categories->count() === 0) {
-                throw new CategoryNotFoundException();
-            }
+            CategoryNotFoundException::throwIfNotFound($categories);
 
             foreach ($categories as $category) {
                 $this->fetchAndStoreJobs($apiKey, $category);

--- a/app/Models/JobCategory.php
+++ b/app/Models/JobCategory.php
@@ -57,7 +57,7 @@ class JobCategory extends Model
     protected function categoryImage(): Attribute
     {
         return Attribute::make(
-            get: fn (string $value) => 'storage/' . $value
+            get: fn (?string $value) => $value !== null ? 'storage/' . $value : ''
         );
     }
 }

--- a/database/migrations/2024_11_30_194710_make_category_image_nullable_in_job_categories_table.php
+++ b/database/migrations/2024_11_30_194710_make_category_image_nullable_in_job_categories_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('job_categories', function (Blueprint $table) {
+            $table->string('category_image')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('job_categories', function (Blueprint $table) {
+            $table->string('category_image')->nullable(false)->change();
+        });
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,13 +17,8 @@ Route::prefix('jobs')->group(function () {
 
 Route::get('/categories', JobCategoryController::class)->name('job.categories');
 
-Route::get('contact', function () {
-    return view('contact');
-})->name('contact');
-
-Route::get('/dashboard', function () {
-    return view('v2.profile.profile');
-})->middleware(['auth', 'verified'])->name('dashboard');
+Route::view('contact', 'contact')->name('contact');
+Route::view('/dashboard', 'v2.profile.profile')->middleware(['auth', 'verified'])->name('dashboard');
 
 Route::get('/profile-update', [ProfileController::class, 'edit'])
     ->middleware(['auth'])


### PR DESCRIPTION
Fixes #29 
This PR adds a user-friendly message when no job categories exist while creating a job listing from the admin dashboard. It also logs an error to the logger file if a queue worker is run without creating a job category. Additionally, it allows the image field to be nullable when creating a job category.