### PR TITLE
fix: latest and most viewed jobs are unique

### DIFF
--- a/app/Http/Controllers/HomePageController.php
+++ b/app/Http/Controllers/HomePageController.php
@@ -37,8 +37,11 @@ class HomePageController extends Controller
             return JobListing::count();
         });
 
-        $latestJobs = Cache::remember('latestJobs', 60 * 24, function () {
-            return JobListing::latest()->limit(15)->get();
+        $latestJobs = Cache::remember('latestJobs', 60 * 24, function () use($mostViewedJobs) {
+            return JobListing::latest()
+                ->whereNotIn('id',$mostViewedJobs->pluck('id')->toArray())
+                ->limit(15)
+                ->get();
         });
 
         return view('v2.index', compact([

--- a/resources/views/components/v2/home/latestJobs.blade.php
+++ b/resources/views/components/v2/home/latestJobs.blade.php
@@ -25,10 +25,6 @@
                                     alt="{{ $job->employer_name }}"
                                     class="h-32 w-full rounded-xl object-cover md:h-full">
                             </a>
-                            <div
-                                class="absolute right-3 top-3 rounded-full bg-pink-500/90 px-3 py-1 text-sm text-white backdrop-blur-sm">
-                                {{ $job->views }} views
-                            </div>
                         </div>
 
                         <!-- Right Side: Job Details -->


### PR DESCRIPTION
Fixed #38 

If a job post contains both the latest and most viewed jobs, this PR ensures the job contains only in most viewed jobs.