### PR TITLE
Added `composer run dev` command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,10 @@
             "@php artisan key:generate --ansi",
             "@php -r \"file_exists('database/database.sqlite') || touch('database/database.sqlite');\"",
             "@php artisan migrate --graceful --ansi"
+        ],
+        "dev": [
+            "Composer\\Config::disableProcessTimeout",
+            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
         ]
     },
     "extra": {


### PR DESCRIPTION
The `composer run dev` command simplifies local development by running the Laravel server, queue listener, npm process, and log monitoring (pail) all at once with a single command.

For details checkout this:  [https://github.com/laravel/laravel/pull/6463](url)