### PR TITLE
PSR-4 Namespace Error - ClassLoader.php line 250

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,11 +30,11 @@
         "psr-4": {
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
-            "Database\\Seeders\\": "database/seeders/",
-            "files": [
-                "app/Helpers/NumberFormatter.php"
-            ]
-        }
+            "Database\\Seeders\\": "database/seeders/"
+        },
+        "files": [
+            "app/Helpers/NumberFormatter.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -31,10 +31,7 @@
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
             "Database\\Seeders\\": "database/seeders/"
-        },
-        "files": [
-            "app/Helpers/NumberFormatter.php"
-        ]
+        }
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
fix(composer): Correct PSR-4 autoload configuration

- Removed redundant 'files' entry for the helper located in the 'app' namespace.
- Ensured all classes and helpers are properly loaded under the 'App\\' namespace.

The helper `NumberFormatter.php` was already included in the `App\\` namespace, so the explicit `files` entry was unnecessary. This resolves the PSR-4 prefix error during `composer install`.