### PR TITLE
Fix invalid files key placement in autoload section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,11 +30,11 @@
         "psr-4": {
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
-            "Database\\Seeders\\": "database/seeders/",
-            "files": [
-                "app/Helpers/NumberFormatter.php"
-            ]
-        }
+            "Database\\Seeders\\": "database/seeders/"
+        },
+        "files": [
+            "app/Helpers/NumberFormatter.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
The files key was incorrectly placed inside the psr-4 section in composer.json.
This commit moves the files key outside the psr-4 section