### PR TITLE
Implement Multiple Job Apply Options

### DIFF
--- a/app/DTO/JobApplyOptionDTO.php
+++ b/app/DTO/JobApplyOptionDTO.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO;
+
+readonly class JobApplyOptionDTO
+{
+    public function __construct(
+        public string $publisher,
+        public string $applyLink,
+        public bool $isDirect,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            publisher: $data['publisher'],
+            applyLink: $data['apply_link'],
+            isDirect: $data['is_direct'] ?? false,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'publisher' => $this->publisher,
+            'apply_link' => $this->applyLink,
+            'is_direct' => $this->isDirect,
+        ];
+    }
+}

--- a/app/DTO/JobDTO.php
+++ b/app/DTO/JobDTO.php
@@ -31,10 +31,23 @@ readonly class JobDTO
         public ?array  $benefits,
         public ?array  $qualifications,
         public ?array  $responsibilities,
+        public ?array  $applyOptions,
     ) {}
 
     public static function fromArray(array $data): self
     {
+        $applyOptions = null;
+        if (isset($data['apply_options']) && is_array($data['apply_options'])) {
+            $applyOptions = [];
+            foreach ($data['apply_options'] as $option) {
+                $applyOptions[] = [
+                    'publisher' => $option['publisher'] ?? '',
+                    'apply_link' => $option['apply_link'] ?? '',
+                    'is_direct' => $option['is_direct'] ?? false,
+                ];
+            }
+        }
+
         return new self(
             jobId: $data['job_id'] ?? null,
             employerName: $data['employer_name'],
@@ -60,7 +73,7 @@ readonly class JobDTO
             benefits: $data['job_highlights']['Benefits'] ?? null,
             qualifications: $data['job_highlights']['Qualifications'] ?? null,
             responsibilities: $data['job_highlights']['Responsibilities'] ?? null,
-
+            applyOptions: $applyOptions,
         );
     }
 

--- a/app/Livewire/ApplyJob.php
+++ b/app/Livewire/ApplyJob.php
@@ -29,7 +29,7 @@ class ApplyJob extends Component
         if (auth()->user()) {
             $this->hasApplied = auth()->user()
                                 ->jobs()
-                                ->where('job_id', $this->job->id)
+                                ->where('job_user.job_id', $this->job->id)
                                 ->exists();
         }
     }

--- a/app/Models/JobApplyOption.php
+++ b/app/Models/JobApplyOption.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class JobApplyOption extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'job_listing_id',
+        'publisher',
+        'apply_link',
+        'is_direct',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'is_direct' => 'boolean',
+        ];
+    }
+
+    public function jobListing(): BelongsTo
+    {
+        return $this->belongsTo(JobListing::class);
+    }
+}

--- a/app/Models/JobListing.php
+++ b/app/Models/JobListing.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 #[ObservedBy([JobListingObserver::class])]
 #[ScopedBy([JobListingScope::class])]
@@ -77,6 +78,11 @@ class JobListing extends Model
         return $this->belongsTo(JobCategory::class, 'job_category', 'id');
     }
 
+    public function applyOptions(): HasMany
+    {
+        return $this->hasMany(JobApplyOption::class);
+    }
+
     public function prunable(): Builder
     {
         return static::query()->where('created_at', '<=', now()->subDays(14));
@@ -107,9 +113,6 @@ class JobListing extends Model
     {
         return 'listing_index';
     }
-
-
-
 
 
 }

--- a/database/migrations/2025_06_08_041322_create_job_apply_options_table.php
+++ b/database/migrations/2025_06_08_041322_create_job_apply_options_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('job_apply_options', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('job_listing_id')->constrained()->cascadeOnDelete();
+            $table->string('publisher');
+            $table->text('apply_link');
+            $table->boolean('is_direct')->default(false);
+            $table->timestamps();
+            
+            $table->index('job_listing_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('job_apply_options');
+    }
+};

--- a/resources/views/livewire/apply-job.blade.php
+++ b/resources/views/livewire/apply-job.blade.php
@@ -1,20 +1,37 @@
 <div>
     <div id="applyjob" class="bg-[#1a1a3a] mt-8 p-6 rounded-2xl border border-gray-700 text-center">
         <h3 class="text-2xl font-semibold mb-4 text-white">Ready to Apply?</h3>
-        <p class="text-gray-300 mb-6">Click the button below to start your application process.</p>
-        <div class="flex justify-center">
-           @if(auth()->check())
-                <a href="{{$job->apply_link}}"
-                   target="__blank"
-                   wire:click="apply" class="px-8 py-3 bg-gradient-to-r from-pink-500 to-purple-600 text-white rounded-lg hover:opacity-90 transition-opacity font-medium text-lg flex items-center gap-2">
-                    <i class="las la-paper-plane text-xl"></i> Apply Now
-                </a>
+        <p class="text-gray-300 mb-6">Choose your preferred application method below.</p>
+        
+        @if(auth()->check())
+            @if($job->applyOptions->isNotEmpty())
+                <div class="space-y-4">
+                    @foreach($job->applyOptions as $option)
+                        <a href="{{ $option->apply_link }}" 
+                           target="_blank"
+                           wire:click="apply" 
+                           class="w-full px-8 py-3 bg-gradient-to-r from-pink-500 to-purple-600 text-white rounded-lg hover:opacity-90 transition-opacity font-medium text-lg flex items-center justify-center gap-2">
+                            <i class="las la-paper-plane text-xl"></i> Apply via {{ $option->publisher }}
+                        </a>
+                    @endforeach
+                </div>
             @else
-                <a href="{{route('login')}}"
-                  class="px-8 py-3 bg-gradient-to-r from-pink-500 to-purple-600 text-white rounded-lg hover:opacity-90 transition-opacity font-medium text-lg flex items-center gap-2">
-                   Please login to apply
+                <div class="flex justify-center">
+                    <a href="{{ $job->apply_link }}"
+                       target="_blank"
+                       wire:click="apply" 
+                       class="px-8 py-3 bg-gradient-to-r from-pink-500 to-purple-600 text-white rounded-lg hover:opacity-90 transition-opacity font-medium text-lg flex items-center gap-2">
+                        <i class="las la-paper-plane text-xl"></i> Apply Now
+                    </a>
+                </div>
+            @endif
+        @else
+            <div class="flex justify-center">
+                <a href="{{ route('login') }}"
+                   class="px-8 py-3 bg-gradient-to-r from-pink-500 to-purple-600 text-white rounded-lg hover:opacity-90 transition-opacity font-medium text-lg flex items-center gap-2">
+                    Please login to apply
                 </a>
-           @endif
-        </div>
+            </div>
+        @endif
     </div>
 </div>


### PR DESCRIPTION
## 📝 Why is PR is required?
This PR implements a new feature that allows job listings to have multiple apply options instead of just a single apply link. This enhancement provides users with more flexibility when applying for jobs, allowing them to choose their preferred application method (direct application, publisher platforms, etc.). It improves the user experience by offering clear choices for job applications and increases the likelihood of successful applications.

## ✅ Checklist

- [ ]  My code follows the project's contribution guidelines.
- [ ]  I have performed a self-review of my code.
- [ ]  I have tested this code locally.

## 🛠️ Changes
- Feature (non-breaking change that adds functionality)
## 📌 Related Issues
None

## 📸 Screenshots
None

## 📣 Additional Comments
This PR includes the following changes:

1. Created a new `job_apply_options` table with migration to store multiple apply options per job
2. Added a `JobApplyOption` model with relationship to `JobListing`
3. Created a `JobApplyOptionDTO` for data transfer
4. Updated the `JobDTO` to include an array of apply options
5. Added a hasMany relationship in the `JobListing` model
6. Updated the `StoreJobs` job to save multiple apply options
7. Modified the `apply-job.blade.php` view to display multiple apply options
8. Fixed an SQL integrity constraint violation in the ApplyJob Livewire component by qualifying the ambiguous `job_id `column

This implementation maintains backward compatibility with existing jobs that have a single apply link while providing enhanced functionality for new jobs with multiple apply options.