### PR TITLE
Fix N+1 query in JobListingCache by eager loading applyOptions relatioship

### DIFF
--- a/app/Caches/JobListingCache.php
+++ b/app/Caches/JobListingCache.php
@@ -11,6 +11,7 @@ class JobListingCache{
     {
         return Cache::remember(self::key($slug), 60 * 24, function () use ($slug) {
             return JobListing::where('slug', $slug)
+                ->with('applyOptions')
                 ->firstOrFail();
         });
     }

--- a/database/factories/JobApplyOptionFactory.php
+++ b/database/factories/JobApplyOptionFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\JobApplyOption;
+use App\Models\JobListing;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\JobApplyOption>
+ */
+class JobApplyOptionFactory extends Factory
+{
+    protected $model = JobApplyOption::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'job_listing_id' => JobListing::factory(),
+            'publisher' => $this->faker->randomElement(['LinkedIn', 'Indeed', 'Glassdoor', 'Monster', 'ZipRecruiter']),
+            'apply_link' => $this->faker->url(),
+            'is_direct' => $this->faker->boolean(70),
+        ];
+    }
+}

--- a/database/factories/JobCategoryFactory.php
+++ b/database/factories/JobCategoryFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\JobCategory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\JobCategory>
+ */
+class JobCategoryFactory extends Factory
+{
+    protected $model = JobCategory::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $name = $this->faker->randomElement([
+            'Software Engineer',
+            'Data Scientist',
+            'Product Manager',
+            'Marketing Manager',
+            'Sales Representative',
+            'Designer',
+            'DevOps Engineer',
+            'Business Analyst'
+        ]);
+
+        return [
+            'name' => $name,
+            'slug' => \Illuminate\Support\Str::slug($name),
+            'query_name' => $name,
+            'page' => 1,
+            'num_page' => 5,
+            'timeframe' => 'week',
+            'category_image' => $this->faker->imageUrl(200, 200),
+        ];
+    }
+}

--- a/database/factories/JobListingFactory.php
+++ b/database/factories/JobListingFactory.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\JobListing;
+use App\Models\JobCategory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\JobListing>
+ */
+class JobListingFactory extends Factory
+{
+    protected $model = JobListing::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'job_id' => $this->faker->unique()->uuid(),
+            'employer_name' => $this->faker->company(),
+            'employer_logo' => $this->faker->imageUrl(100, 100),
+            'employer_website' => $this->faker->url(),
+            'employer_company_type' => $this->faker->randomElement(['Private', 'Public', 'Non-profit']),
+            'publisher' => $this->faker->randomElement(['LinkedIn', 'Indeed', 'Glassdoor', 'Monster']),
+            'employment_type' => $this->faker->randomElement(['Full-time', 'Part-time', 'Contract', 'Freelance']),
+            'job_title' => $this->faker->jobTitle(),
+            'job_category' => JobCategory::factory(),
+            'category_image' => $this->faker->imageUrl(200, 200),
+            'apply_link' => $this->faker->url(),
+            'description' => $this->faker->paragraphs(3, true),
+            'is_remote' => $this->faker->boolean(30),
+            'city' => $this->faker->city(),
+            'state' => $this->faker->state(),
+            'country' => $this->faker->countryCode(),
+            'latitude' => $this->faker->latitude(),
+            'longitude' => $this->faker->longitude(),
+            'google_link' => $this->faker->url(),
+            'posted_at' => $this->faker->dateTimeBetween('-30 days', 'now'),
+            'expired_at' => $this->faker->dateTimeBetween('now', '+30 days'),
+            'min_salary' => $this->faker->numberBetween(30000, 80000),
+            'max_salary' => $this->faker->numberBetween(80000, 150000),
+            'salary_currency' => 'USD',
+            'salary_period' => $this->faker->randomElement(['year', 'month', 'hour']),
+            'benefits' => $this->faker->randomElements([
+                'Health Insurance',
+                'Dental Insurance',
+                'Vision Insurance',
+                '401k',
+                'Paid Time Off',
+                'Flexible Schedule',
+                'Remote Work',
+                'Professional Development'
+            ], $this->faker->numberBetween(2, 5)),
+            'qualifications' => $this->faker->sentences(5),
+            'responsibilities' => $this->faker->sentences(8),
+            'required_experience' => $this->faker->numberBetween(0, 10),
+        ];
+    }
+}

--- a/tests/Unit/Caches/JobListingCacheTest.php
+++ b/tests/Unit/Caches/JobListingCacheTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Unit\Caches;
+
+use Tests\TestCase;
+use App\Models\JobListing;
+use App\Models\JobApplyOption;
+use App\Caches\JobListingCache;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class JobListingCacheTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_job_listing_cache_eager_loads_apply_options()
+    {
+        // Create a job listing
+        $job = JobListing::factory()->create([
+            'slug' => 'test-job-slug',
+            'job_title' => 'Test Job',
+            'employer_name' => 'Test Company'
+        ]);
+
+        // Create apply options for the job
+        JobApplyOption::factory()->create([
+            'job_listing_id' => $job->id,
+            'publisher' => 'LinkedIn',
+            'apply_link' => 'https://linkedin.com/jobs/test',
+            'is_direct' => true
+        ]);
+
+        JobApplyOption::factory()->create([
+            'job_listing_id' => $job->id,
+            'publisher' => 'Indeed',
+            'apply_link' => 'https://indeed.com/jobs/test',
+            'is_direct' => false
+        ]);
+
+        // Clear any existing cache
+        \Illuminate\Support\Facades\Cache::forget(JobListingCache::key('test-job-slug'));
+
+        // Get the job from cache
+        $cachedJob = JobListingCache::get('test-job-slug');
+
+        // Verify the job is loaded
+        $this->assertInstanceOf(JobListing::class, $cachedJob);
+        $this->assertEquals('test-job-slug', $cachedJob->slug);
+
+        // Verify apply options are eager loaded (no additional queries)
+        $this->assertTrue($cachedJob->relationLoaded('applyOptions'));
+        $this->assertCount(2, $cachedJob->applyOptions);
+        
+        // Verify the apply options data
+        $publishers = $cachedJob->applyOptions->pluck('publisher')->toArray();
+        $this->assertContains('LinkedIn', $publishers);
+        $this->assertContains('Indeed', $publishers);
+    }
+
+    public function test_job_listing_cache_handles_job_without_apply_options()
+    {
+        // Create a job listing without apply options
+        $job = JobListing::factory()->create([
+            'slug' => 'test-job-no-options',
+            'job_title' => 'Test Job No Options',
+            'employer_name' => 'Test Company'
+        ]);
+
+        // Clear any existing cache
+        \Illuminate\Support\Facades\Cache::forget(JobListingCache::key('test-job-no-options'));
+
+        // Get the job from cache
+        $cachedJob = JobListingCache::get('test-job-no-options');
+
+        // Verify the job is loaded
+        $this->assertInstanceOf(JobListing::class, $cachedJob);
+        $this->assertEquals('test-job-no-options', $cachedJob->slug);
+
+        // Verify apply options relationship is loaded but empty
+        $this->assertTrue($cachedJob->relationLoaded('applyOptions'));
+        $this->assertCount(0, $cachedJob->applyOptions);
+    }
+}


### PR DESCRIPTION
- Add ->with('applyOptions') to JobListingCache::get() method
- This prevents N+1 queries when ApplyJob Livewire component accesses applyOptions
- Resolves GEEZAP-93: N+1 Query issue in StoreJobs

The issue was occurring because:
1. JobListingCache loaded jobs without eager loading applyOptions
2. ApplyJob Livewire component accessed $job->applyOptions in Blade template
3. This triggered lazy loading of applyOptions for each job, causing N+1 queries

Fix ensures applyOptions are loaded in a single query when the job is cached.

Additional improvements:
- Add JobListingFactory, JobApplyOptionFactory, and JobCategoryFactory for testing
- Add JobListingCacheTest to verify eager loading works correctly
